### PR TITLE
Move relationship filtering to backend with Neo4j

### DIFF
--- a/app/blueprints/comp_graph_bp.py
+++ b/app/blueprints/comp_graph_bp.py
@@ -35,3 +35,31 @@ async def get_surrounding_by_node(
     result = await comp_graph_service.get_surrounding_by_node(node_id, expand_number_of_layers)
 
     return result.dict()
+
+
+@comp_graph_controller.get("/api/comp/surrounding/new")
+@validate_querystring(GetSurroundingByNodeRequest)
+@inject
+async def bfs(
+        query_args: GetSurroundingByNodeRequest,
+        comp_graph_service: CompGraphService = Provide[
+            ApplicationContainer.comp_graph_bp.comp_graph_svc
+        ],
+):
+    node_id = query_args.node_id
+    expand_number_of_layers = query_args.expand_number_of_layers
+    if node_id is None:
+        return {"message": "node_id can not be empty"}, http.HTTPStatus.BAD_REQUEST
+    if expand_number_of_layers is None:
+        return {"message": "expand_number_of_layers can not be empty"}, http.HTTPStatus.BAD_REQUEST
+
+    # below flags are true by default if not included in the request
+    competition = query_args.competition
+    product = query_args.product
+    other = query_args.other
+    unknown = query_args.unknown
+    flags = [competition, product, other, unknown]
+
+    result = await comp_graph_service.bfs(node_id, expand_number_of_layers, flags)
+
+    return result

--- a/app/entities/graph_dto.py
+++ b/app/entities/graph_dto.py
@@ -5,3 +5,7 @@ from pydantic.class_validators import Optional
 class GetSurroundingByNodeRequest(BaseModel):
     node_id: Optional[int] = Field(None, description="The center of the displayed graph")
     expand_number_of_layers: Optional[int] = Field(None, description="Number of neighboring layers to include in the graph")
+    competition: Optional[bool] = Field(True, description="If to include competition relationships in the graph")
+    product: Optional[bool] = Field(True, description="If to include product relationships in the graph")
+    other: Optional[bool] = Field(True, description="If to include other relationships in the graph")
+    unknown: Optional[bool] = Field(True, description="If to include unknown relationships in the graph")

--- a/app/services/comp_graph_service.py
+++ b/app/services/comp_graph_service.py
@@ -1,8 +1,13 @@
 import abc
+
 from app.entities.graph_entities import Graph
 
 
 class CompGraphService(abc.ABC):
     @abc.abstractmethod
     async def get_surrounding_by_node(self, node_id: int, expand_number_of_layers: int) -> Graph:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def bfs(self, node_id: int, expand_number_of_layers: int, flags: list):
         raise NotImplementedError

--- a/app/services/comp_graph_service_impl.py
+++ b/app/services/comp_graph_service_impl.py
@@ -1,3 +1,5 @@
+from neo4j import GraphDatabase
+
 from app.services.comp_graph_service import CompGraphService
 from app.repository.comp_graph_repository import CompanyGraphDao
 from app.entities.graph_entities import Graph
@@ -12,3 +14,62 @@ class CompGraphServiceImpl(CompGraphService):
             node_id, expand_number_of_layers
         )
         return surrounding
+
+    async def bfs(self, node_id, expand_number_of_layers, flags):
+        uri = 'bolt://172.17.0.2:7687'
+        user = 'neo4j'
+        password = 'graph2023'
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+
+        # [abandoned] bfs get nodes then query edges? if so, get nodeIds instead of path
+        # [abandoned] problem: no 'unknown' relationType exists in dow30 graph, including it in types will cause error
+        # bfs_query = """
+        #             MATCH (source:Node{id:'$node_id'})
+        #             CALL gds.bfs.stream('dow30', {
+        #               sourceNode: source,
+        #               maxDepth: $depth,
+        #               relationshipTypes: $types
+        #             })
+        #             YIELD path
+        #             CALL apoc.graph.fromPaths([path],'test', {})
+        #             YIELD graph AS g
+        #             RETURN g.nodes
+        #             """
+
+        # bfs_query = bfs_query.replace('$node_id', str(node_id))
+        # bfs_query = bfs_query.replace('$depth', str(expand_number_of_layers))
+        # bfs_query = bfs_query.replace('$types', str(types))
+
+        # with driver.session() as session:
+        #     results = session.read_transaction(
+        #         lambda tx: tx.run(bfs_query).data())
+
+        types = ['competition', 'product', 'other', 'unknown']
+
+        types_str = ''
+        for i in range(len(flags)):
+            if flags[i]:
+                types_str += types[i] + '|'
+        types_str = types_str[:-1]
+
+        query = '''
+        MATCH (source:Node{id: '$node_id'})
+        CALL apoc.path.subgraphAll(source, {
+            relationshipFilter: '$types',
+            minLevel: 0,
+            maxLevel: $depth
+        })
+        YIELD nodes, relationships
+        RETURN nodes, relationships; 
+        '''
+
+        query = query.replace('$node_id', str(node_id))
+        query = query.replace('$depth', str(expand_number_of_layers))
+        query = query.replace('$types', types_str)
+
+        with driver.session() as session:
+            results = session.read_transaction(
+                lambda tx: tx.run(query).data())
+
+        driver.close()
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ Werkzeug==2.2.2
 wsproto==1.2.0
 Flask-Cors==3.0.10
 quart-cors==0.6.0
+neo4j==5.14.1

--- a/settings.py
+++ b/settings.py
@@ -8,3 +8,8 @@ TRAIN_FILE_LOCATION = os.getenv('TRAIN_FILE_LOCATION', "app/data/train2id.txt")
 TEST_ENTITY_FILE_LOCATION = os.getenv('TEST_ENTITY_FILE_LOCATION', "tests/data/test_entity.txt")
 TEST_RELATION_FILE_LOCATION = os.getenv('TEST_RELATION_FILE_LOCATION', "tests/data/test_relation.txt")
 TEST_TRAIN_FILE_LOCATION = os.getenv('TEST_TRAIN_FILE_LOCATION', "tests/data/test_graph.txt")
+
+# TODO: modify this accordingly to connect to Neo4j
+NEO4J_GRAPH_DB_URI = 'bolt://172.17.0.2:7687'
+NEO4J_GRAPH_DB_USER = 'neo4j'
+NEO4J_GRAPH_DB_PASSWORD = 'graph2023'


### PR DESCRIPTION
Update:

- New endpoint `/api/comp/surrounding/new` for getting filtered surrounding nodes directly.
  - new optional params: 'competition','other','product', and 'unknown' - will be set as True by default at backend if not included in the request
  - example request: `{PATH}/api/comp/surrounding/new?node_id=175&expand_number_of_layers=1&competition=True&other=False&product=True&unknown=False`
  - response structure same as the original endpoint, except that link's 'id' attribute is removed (which shouldn't affect the display based on my review of frontend code - let me know if it does)
  - example response: `{
    "links": [
        {
            "category": "competition",
            "source": "175",
            "target": "178"
        },
        {
            "category": "competition",
            "source": "175",
            "target": "179"
        }
    ],
    "nodes": [
        {
            "id": "175",
            "name": "NKE"
        },
        {
            "id": "178",
            "name": "SYNC.1"
        },
        {
            "id": "179",
            "name": "VFC"
        }
    ]
}`

Testing:

- Deployed backend and neo4j instance on docker containers and tested with Postman.